### PR TITLE
Selector support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ store.Reducer(func(state gredux.State, action gredux.Action) (gredux.State, inte
 		return counterState{state.(counterState).count + action.Data.(int)}, nil
 	case "decrement":
 		return counterState{state.(counterState).count - action.Data.(int)}, nil
-  case "get"
+	case "get"
 		return state, state.(counterState).count
 	default:
 		return state, nil

--- a/README.md
+++ b/README.md
@@ -22,27 +22,30 @@ type counterState struct {
 // Instantiate a new store around this state
 store := gredux.New(counterState{0})
 
-// Create a reducer which increments "count" when it receives an "increment" 
+// Create a reducer which increments "count" when it receives an "increment"
 // action, and decrements when it receives a "decrement" action.
-store.Reducer(func(state gredux.State, action gredux.Action) gredux.State {
+// Note: the second return value is the value returned by Dispatch -- useful for selectors
+store.Reducer(func(state gredux.State, action gredux.Action) (gredux.State, interface{}) {
 	switch action.ID {
 	case "increment":
-		return counterState{state.(counterState).count + action.Data.(int)}
+		return counterState{state.(counterState).count + action.Data.(int)}, nil
 	case "decrement":
-		return counterState{state.(counterState).count - action.Data.(int)}
+		return counterState{state.(counterState).count - action.Data.(int)}, nil
+  case "get"
+		return state, state.(counterState).count
 	default:
-		return state
+		return state, nil
 	}
 })
 
 store.Dispatch(Action{"increment", 5})
 store.Dispatch(Action{"decrement", 2})
 
-fmt.Println(store.State().(counterState).count) // prints 3
+fmt.Println(store.Dispatch(Action{"get", nil})) // prints 3
 
 // Register a func to be called after each state update
 store.AfterUpdate(func(state State) {
-	fmt.Println(state.(counterState).count) // prints the count after every state update
+  fmt.Println(store.Dispatch(Action{"get", nil})) // prints the count after every state update
 })
 store.Dispatch(Action{"decrement", 2})
 ```

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ fmt.Println(store.Dispatch(Action{"get", nil})) // prints 3
 
 // Register a func to be called after each state update
 store.AfterUpdate(func(state State) {
-  fmt.Println(store.Dispatch(Action{"get", nil})) // prints the count after every state update
+	fmt.Println(store.Dispatch(Action{"get", nil})) // prints the count after every state update
 })
 store.Dispatch(Action{"decrement", 2})
 ```

--- a/gredux.go
+++ b/gredux.go
@@ -34,7 +34,7 @@ type (
 func New(initialState State) *Store {
 	st := Store{
 		reducer: func(s State, a Action) State {
-			return s
+			return s, _
 		},
 		state: initialState,
 	}
@@ -65,11 +65,12 @@ func (st *Store) State() State {
 }
 
 // Dispatch dispatches an Action into the Store.
-func (st *Store) Dispatch(action Action) {
+func (st *Store) Dispatch(action Action) interface{} {
 	st.mu.Lock()
 	defer st.mu.Unlock()
-	st.state = st.reducer(st.getState(), action)
+	st.state, ret = st.reducer(st.getState(), action)
 	if st.update != nil {
 		st.update(st.getState())
 	}
+	return ret
 }

--- a/gredux.go
+++ b/gredux.go
@@ -68,7 +68,7 @@ func (st *Store) State() State {
 func (st *Store) Dispatch(action Action) interface{} {
 	st.mu.Lock()
 	defer st.mu.Unlock()
-  newState, ret := st.reducer(st.getState(), action)
+	newState, ret := st.reducer(st.getState(), action)
 	st.state = newState
 	if st.update != nil {
 		st.update(st.getState())

--- a/gredux.go
+++ b/gredux.go
@@ -10,7 +10,7 @@ type (
 
 	// Reducer is the func which receives actions dispatched
 	// using Store.Dispatch() and updates the internal state.
-	Reducer func(State, Action) State
+	Reducer func(State, Action) (State, interface{})
 
 	// Action defines a dispatchable data type that triggers updates in the Store.
 	Action struct {
@@ -33,8 +33,8 @@ type (
 // initialState should be the struct used to define the Store's state.
 func New(initialState State) *Store {
 	st := Store{
-		reducer: func(s State, a Action) State {
-			return s, _
+		reducer: func(s State, a Action) (State, interface{}) {
+			return s, nil
 		},
 		state: initialState,
 	}
@@ -68,7 +68,8 @@ func (st *Store) State() State {
 func (st *Store) Dispatch(action Action) interface{} {
 	st.mu.Lock()
 	defer st.mu.Unlock()
-	st.state, ret = st.reducer(st.getState(), action)
+  newState, ret := st.reducer(st.getState(), action)
+	st.state = newState
 	if st.update != nil {
 		st.update(st.getState())
 	}

--- a/gredux_test.go
+++ b/gredux_test.go
@@ -166,3 +166,26 @@ func BenchmarkDispatch(b *testing.B) {
 		store.Dispatch(Action{"increment", nil})
 	}
 }
+
+func TestConcurrentSelectorSupport(t *testing.T) {
+	type testState struct {
+		success bool
+	}
+	store := New(testState{false})
+	store.Reducer(func(state State, action Action) State {
+		switch action.ID {
+		case "select":
+			return state, state.select
+		default:
+			return testState{true}, _
+	})
+	for i := 0; i < 10; i++ {
+		go func() {
+			time.Sleep(time.Second * time.Duration(rand.Int()))
+			ret := store.Dispatch(Action{"select", nil})
+			if ret != true {
+				t.Error("Selector failed")
+			}
+		}()
+	}
+}


### PR DESCRIPTION
Added second return value from reducers which gets passed through Dispatch to the caller.  This allows us to use selectors, though I admit having the interface{} type as well as needing `, nil` all over the place is not ideal.

I'm new to Golang, so there might be a better way to do this...