### PR TITLE
feat: hook for actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ store.AfterUpdate(func(state State) {
 })
 
 // Register a hook for given action that will be invoked everytime that action is dispatched 
+// This hook must not dispatch another action otherwise deadlock will happen!
 store.AddHook(func(state State) {
 	fmt.Println(state.(counterState).count) // prints the count after every state update
 }, []string{"increment"})

--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ fmt.Println(store.State().(counterState).count) // prints 3
 store.AfterUpdate(func(state State) {
 	fmt.Println(state.(counterState).count) // prints the count after every state update
 })
+
+// Register a hook for given action that will be invoked everytime that action is dispatched 
+store.AddHook(func(state State) {
+	fmt.Println(state.(counterState).count) // prints the count after every state update
+}, []string{"increment"})
 store.Dispatch(Action{"decrement", 2})
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/auhau/gredux
+
+go 1.17

--- a/gredux.go
+++ b/gredux.go
@@ -55,6 +55,7 @@ func (st *Store) AfterUpdate(update func(State)) {
 }
 
 // AddHook adds a hook which is invoked for specific actions that are specified as second argument
+// The hook must not dispatch another actions otherwise deadlock will happen!
 func (st *Store) AddHook(hook func(State), actions []string)  {
 	for _, action := range actions {
 		if actionHooks, exists := st.hooks[action]; exists{

--- a/gredux.go
+++ b/gredux.go
@@ -26,6 +26,7 @@ type (
 		reducer Reducer
 		state   State
 		update  func(State)
+		hooks   map[string][]func(State)
 	}
 )
 
@@ -37,6 +38,7 @@ func New(initialState State) *Store {
 			return s
 		},
 		state: initialState,
+		hooks: map[string][]func(State){},
 	}
 	return &st
 }
@@ -50,6 +52,17 @@ func (st *Store) Reducer(r Reducer) {
 // dispatch with a copy of the new state.
 func (st *Store) AfterUpdate(update func(State)) {
 	st.update = update
+}
+
+// AddHook adds a hook which is invoked for specific actions that are specified as second argument
+func (st *Store) AddHook(hook func(State), actions []string)  {
+	for _, action := range actions {
+		if actionHooks, exists := st.hooks[action]; exists{
+			st.hooks[action] = append(actionHooks, hook)
+		} else {
+			st.hooks[action] = []func(State){hook}
+		}
+	}
 }
 
 // getState returns a copy of Store's current state map.
@@ -68,8 +81,14 @@ func (st *Store) State() State {
 func (st *Store) Dispatch(action Action) {
 	st.mu.Lock()
 	defer st.mu.Unlock()
+
 	st.state = st.reducer(st.getState(), action)
 	if st.update != nil {
 		st.update(st.getState())
+	}
+
+	actionHooks := st.hooks[action.ID]
+	for _, hook := range actionHooks {
+		hook(st.getState())
 	}
 }


### PR DESCRIPTION
Not sure if this will be accepted, but I needed it for my application anyhow so I am offering it as PR.

This PR adds support for hook functions that are invoked similarly like `AfterUpdate` but you can add several for them and target them on dedicated actions.